### PR TITLE
Modal popup wrong time fix

### DIFF
--- a/src/components/dashboard/components/ZeroReFiTokensPopUpModal.tsx
+++ b/src/components/dashboard/components/ZeroReFiTokensPopUpModal.tsx
@@ -1,5 +1,4 @@
 import { FC } from "react";
-import { Navigate, useNavigate } from "react-router-dom";
 
 import {
   Modal,
@@ -10,6 +9,8 @@ import {
   Button,
 } from "@chakra-ui/react";
 
+import { useNavigate } from "react-router-dom";
+
 interface ZeroReFiTokensPopupModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -17,12 +18,15 @@ interface ZeroReFiTokensPopupModalProps {
 }
 
 const ZeroReFiTokensPopupModal: FC<ZeroReFiTokensPopupModalProps> = ({ isOpen, onClose, zeroRefiTokens, }) => {
-  
+  const navigate = useNavigate();
 
   const handleClick = () => {
+
+    navigate("/marketplace")
+
     window.scrollTo({
-        top: 1250, // Replace 500 with the desired Y-coordinate
-        behavior: 'smooth' // Optional: enables smooth scrolling
+        top: 2000, 
+        behavior: 'smooth' 
     });
     onClose(); 
   };

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -18,12 +18,6 @@ import { D, d } from "../../web3/util/d";
 import { formatReFi } from "../../web3/solana/staking/util";
 import ZeroReFiTokensPopupModal from "./components/ZeroReFiTokensPopUpModal";
 
-
-const sessionManager = {
-  get: (key: string) => sessionStorage.getItem(key),
-  set: (key: string, value: string) => sessionStorage.setItem(key, value)
-};
-
 const DashboardContent: FC = () => {
   const { historicalPrices, currentPrice } = useAppSelector(
     (state) => state.price,
@@ -67,27 +61,19 @@ const DashboardContent: FC = () => {
     }
   }, [anchorWallet]);
 
+  useEffect(() => {
+    if (!sessionStorage.getItem("popUpModalShown")) {
+      setPopupModalOpen(true);
+      sessionStorage.setItem("popUpModalShown", "true");
+    } 
+  }, []);
   
   useEffect(() => {
     console.log("your current refi balance is: " + totalHumanReFi)
   }, [totalHumanReFi]);
 
-  useEffect(() => {  
-    const hasPopUpModalBeenShown = sessionManager.get("hasPopUpModalBeenShown");
-
-    if (!hasPopUpModalBeenShown) {      
-      setPopupModalOpen(true);
-    }
-      
-    
-    console.log("upon page load, hasModalBeenShown: " + sessionManager.get("hasPopUpModalBeenShown"));
-
-  }, []);
-
   const handleCloseModal = () => {
     setPopupModalOpen(false);
-
-    sessionManager.set("hasPopUpModalBeenShown", "true");
   };
 
   if (!wallet.publicKey) {

--- a/src/components/marketplace/index.tsx
+++ b/src/components/marketplace/index.tsx
@@ -7,11 +7,6 @@ import { useWallet, useAnchorWallet } from "@solana/wallet-adapter-react";
 import ConnectWalletModal from "../connect-wallet-modal";
 import { Button } from "@chakra-ui/react";
 import { env } from "../../env";
-import { getTotalReFi } from "../../web3/solana/staking/service/getTotalReFi";
-import { D, d } from "../../web3/util/d";
-import { formatReFi } from "../../web3/solana/staking/util";
-// import { ZeroReFiTokensPopupModal } from "./components/RevealNFTModal";
-import ZeroRefiTokensPopUpModal from "./components/ZeroReFiTokensPopUpModal"
 
 const tabOptions = [
   "NFT Collection",
@@ -25,11 +20,6 @@ const MarketplaceContent: FC = () => {
   const [isModalOpen, setModalOpen] = useState(true);
   const wallet = useWallet();
   const candyMachine = useCandyMachine();
-  
-  const [totalHumanReFi, setTotalHumanReFi] = useState<number | null>(null);
-  const anchorWallet = useAnchorWallet();
-  // const [showZeroReFiTokensModal, setShowZeroReFiTokensModal] = useState(false);
-
 
   const STARTING_FROM_PRICE = 125_000;
   const hiddenNftCount = (candyMachine?.items?.length || 250) - env.REACT_APP_MAX_NFT_AVAILABLE
@@ -50,20 +40,6 @@ const MarketplaceContent: FC = () => {
     { value: `${volumeTraded.toLocaleString()} $REFI`, name: "Volume traded" },
     { value: "90 days", name: "Ownership Duration" },
   ];
-
-  useEffect(() => {
-    if (anchorWallet) {
-      getTotalReFi(anchorWallet.publicKey).then((value) => {
-        setTotalHumanReFi(Math.trunc(d(value)));
-      });
-    }
-  }, [anchorWallet, wallet.publicKey]);
-
-
-  const handleCloseModal = () => {
-    setModalOpen(false);
-  };
-  
 
   if (!wallet.publicKey) {
     return (
@@ -106,14 +82,6 @@ const MarketplaceContent: FC = () => {
           <TabContent activeTab={activeTab} />
         </div>
       </div>
-      
-      {isModalOpen &&  totalHumanReFi != null && (
-        <ZeroRefiTokensPopUpModal 
-          isOpen={isModalOpen} 
-          onClose={handleCloseModal}
-          zeroRefiTokens={totalHumanReFi === 0}
-        />
-      )}
     </div>
   );
 };


### PR DESCRIPTION
When a user connects their wallet, the first time that they land on the dashboard page they will encounter a pop up. 

Upon closing the pop up, if the user navigates to another page (i.e. /marketplace, /staking, etc...) and back to dashboard then they will not encounter the pop up again.

Essentially the popup only appears ONCE in a user's session on the app. 



https://github.com/user-attachments/assets/ffb590a1-3d66-4421-bed1-e26249be8262



