### PR TITLE
Updated banner staking page so that the message displayed is changed if the user has staked an NFT

### DIFF
--- a/src/components/dashboard/components/ZeroReFiTokensPopUpModal.tsx
+++ b/src/components/dashboard/components/ZeroReFiTokensPopUpModal.tsx
@@ -1,5 +1,4 @@
 import { FC } from "react";
-import { Navigate, useNavigate } from "react-router-dom";
 
 import {
   Modal,
@@ -10,6 +9,8 @@ import {
   Button,
 } from "@chakra-ui/react";
 
+import { useNavigate } from "react-router-dom";
+
 interface ZeroReFiTokensPopupModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -17,12 +18,15 @@ interface ZeroReFiTokensPopupModalProps {
 }
 
 const ZeroReFiTokensPopupModal: FC<ZeroReFiTokensPopupModalProps> = ({ isOpen, onClose, zeroRefiTokens, }) => {
-  
+  const navigate = useNavigate();
 
   const handleClick = () => {
+
+    navigate("/marketplace")
+
     window.scrollTo({
-        top: 1250, // Replace 500 with the desired Y-coordinate
-        behavior: 'smooth' // Optional: enables smooth scrolling
+        top: 2000, 
+        behavior: 'smooth' 
     });
     onClose(); 
   };

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -18,12 +18,6 @@ import { D, d } from "../../web3/util/d";
 import { formatReFi } from "../../web3/solana/staking/util";
 import ZeroReFiTokensPopupModal from "./components/ZeroReFiTokensPopUpModal";
 
-
-const sessionManager = {
-  get: (key: string) => sessionStorage.getItem(key),
-  set: (key: string, value: string) => sessionStorage.setItem(key, value)
-};
-
 const DashboardContent: FC = () => {
   const { historicalPrices, currentPrice } = useAppSelector(
     (state) => state.price,
@@ -67,27 +61,19 @@ const DashboardContent: FC = () => {
     }
   }, [anchorWallet]);
 
+  useEffect(() => {
+    if (!sessionStorage.getItem("popUpModalShown")) {
+      setPopupModalOpen(true);
+      sessionStorage.setItem("popUpModalShown", "true");
+    } 
+  }, []);
   
   useEffect(() => {
     console.log("your current refi balance is: " + totalHumanReFi)
   }, [totalHumanReFi]);
 
-  useEffect(() => {  
-    const hasPopUpModalBeenShown = sessionManager.get("hasPopUpModalBeenShown");
-
-    if (!hasPopUpModalBeenShown) {      
-      setPopupModalOpen(true);
-    }
-      
-    
-    console.log("upon page load, hasModalBeenShown: " + sessionManager.get("hasPopUpModalBeenShown"));
-
-  }, []);
-
   const handleCloseModal = () => {
     setPopupModalOpen(false);
-
-    sessionManager.set("hasPopUpModalBeenShown", "true");
   };
 
   if (!wallet.publicKey) {

--- a/src/components/marketplace/index.tsx
+++ b/src/components/marketplace/index.tsx
@@ -7,11 +7,6 @@ import { useWallet, useAnchorWallet } from "@solana/wallet-adapter-react";
 import ConnectWalletModal from "../connect-wallet-modal";
 import { Button } from "@chakra-ui/react";
 import { env } from "../../env";
-import { getTotalReFi } from "../../web3/solana/staking/service/getTotalReFi";
-import { D, d } from "../../web3/util/d";
-import { formatReFi } from "../../web3/solana/staking/util";
-// import { ZeroReFiTokensPopupModal } from "./components/RevealNFTModal";
-import ZeroRefiTokensPopUpModal from "./components/ZeroReFiTokensPopUpModal"
 
 const tabOptions = [
   "NFT Collection",
@@ -25,11 +20,6 @@ const MarketplaceContent: FC = () => {
   const [isModalOpen, setModalOpen] = useState(true);
   const wallet = useWallet();
   const candyMachine = useCandyMachine();
-  
-  const [totalHumanReFi, setTotalHumanReFi] = useState<number | null>(null);
-  const anchorWallet = useAnchorWallet();
-  // const [showZeroReFiTokensModal, setShowZeroReFiTokensModal] = useState(false);
-
 
   const STARTING_FROM_PRICE = 125_000;
   const hiddenNftCount = (candyMachine?.items?.length || 250) - env.REACT_APP_MAX_NFT_AVAILABLE
@@ -50,20 +40,6 @@ const MarketplaceContent: FC = () => {
     { value: `${volumeTraded.toLocaleString()} $REFI`, name: "Volume traded" },
     { value: "90 days", name: "Ownership Duration" },
   ];
-
-  useEffect(() => {
-    if (anchorWallet) {
-      getTotalReFi(anchorWallet.publicKey).then((value) => {
-        setTotalHumanReFi(Math.trunc(d(value)));
-      });
-    }
-  }, [anchorWallet, wallet.publicKey]);
-
-
-  const handleCloseModal = () => {
-    setModalOpen(false);
-  };
-  
 
   if (!wallet.publicKey) {
     return (
@@ -106,14 +82,6 @@ const MarketplaceContent: FC = () => {
           <TabContent activeTab={activeTab} />
         </div>
       </div>
-      
-      {isModalOpen &&  totalHumanReFi != null && (
-        <ZeroRefiTokensPopUpModal 
-          isOpen={isModalOpen} 
-          onClose={handleCloseModal}
-          zeroRefiTokens={totalHumanReFi === 0}
-        />
-      )}
     </div>
   );
 };

--- a/src/components/staking/components/StakingPoolOptionsModal.tsx
+++ b/src/components/staking/components/StakingPoolOptionsModal.tsx
@@ -89,12 +89,6 @@ const StakingPoolOptionsModal: FC<StakingPoolOptionsModalProps> = ({
           status: "success",
         });
         
-        // successfully tested that the modal appears correctly 
-        // however have not tested whether it appears in the case that a lock period stake is executed 
-        // This is due to the fact that I am unable to buy an NFT while testing / on devnet 
-        // however this implementation should:
-          // cause the page to be scrolled down to my stakes & rewards
-          // a popup then appears suggesting that the user should restake for higher rewards
         if (lockPeriod != 0) {
           try {
             setRestakeModalOpen(true);
@@ -103,12 +97,6 @@ const StakingPoolOptionsModal: FC<StakingPoolOptionsModalProps> = ({
             console.error(e);
           }
         }
-
-        
-        // window.scrollTo({
-        //   top: document.documentElement.scrollHeight, // Scroll to the bottom
-        //   behavior: 'smooth', // Smooth scrolling
-        // });
 
 
       } catch (e: any) {

--- a/src/components/staking/components/StakingPromoBanner.tsx
+++ b/src/components/staking/components/StakingPromoBanner.tsx
@@ -1,17 +1,58 @@
-import { FC } from "react";
+import { FC, useEffect, useState } from "react";
+import { getStakedNfts } from "../../../web3/solana/service/getStakedNfts";
+import { useAnchorWallet, useWallet } from "@solana/wallet-adapter-react";
+import { Stake } from "../../../web3/solana/staking/types";
+import { useStakes, useUmi } from "../../../web3/solana/hook";
+import { getMyStakes } from "../../../web3/solana/staking/service/getMyStakes";
 
-const StakingPromoBanner: FC = () => (
-  <div
-    className="flex h-[137px] max-h-fit w-full items-center rounded-[15px] border border-[#333333] bg-contain bg-left bg-no-repeat"
-    style={{ backgroundImage: `url('./images/staking-promo-image.png')` }}
-  >
-    <div className="ml-4 mr-4 md:ml-52">
-      <p className="font-sans text-base text-white">
-        Harness the benefits of compounding by staking your tokens and
-        reinvesting the rewards as they accumulate.
-      </p>
+const StakingPromoBanner: FC = () => {
+
+  const [stakes, setStakes] = useState<Stake[]>([]);
+  const [isRestakeMessage, setRestakeMessage] = useState(false);
+
+  const anchorWallet = useAnchorWallet();
+  const wallet = useWallet();
+  const umi = useUmi(wallet);
+
+  useEffect(() => {
+    const loadStakes = async () => {
+      if (!anchorWallet || !umi || !wallet.connected) {
+        setStakes([]);
+        return;
+      }
+
+      try {
+        const [fetchedStakes] = await Promise.all([
+          getMyStakes(anchorWallet),
+        ]);
+        console.log("FETCHED STAKES: " + fetchedStakes)
+        setStakes(fetchedStakes);
+      } catch (error) {
+        console.error("Error fetching stakes or NFTs:", error);
+      }
+    };
+
+    loadStakes();
+  }, [anchorWallet, umi, wallet.connected]);
+
+  useEffect(() => {
+    if (stakes.filter(stake => stake.nft != null).length > 0) {
+      setRestakeMessage(true);
+    }
+  }, [stakes]);
+
+  return (
+    <div
+      className="flex h-[137px] max-h-fit w-full items-center rounded-[15px] border border-[#333333] bg-contain bg-left bg-no-repeat"
+      style={{ backgroundImage: `url('./images/staking-promo-image.png')` }}
+    >
+      <div className="ml-4 mr-4 md:ml-52">
+        <p className="font-sans text-base text-white">
+          {isRestakeMessage ? "You can get more $REFI upfront if you restake all your stakes now!"  : "Harness the benefits of compounding by staking your tokens and reinvesting the rewards as they accumulate."}
+        </p>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default StakingPromoBanner;

--- a/src/components/staking/index.tsx
+++ b/src/components/staking/index.tsx
@@ -57,7 +57,7 @@ const StakingContent: FC = () => {
   const umi = useUmi(walletContext);
   const [allStakesAccs, setAllStakesAccs] = useState<StakeInfoAccount[]>([]);
   const { stakes } = useStakes(anchorWallet);
-console.log("stakes", stakes)
+  
   useEffect(() => {
     getAllStakes().then(setAllStakesAccs);
   }, []);


### PR DESCRIPTION
The banner now appears with the message 

"You can get more $REFI upfront if you restake all your stakes now!"

Not sure how to calculate the rewards based on the day so I chose this message as a placeholder. However after figuring this out, the message can simply be changed to

"You can get x $REFI upfront if you restake all your stakes now!"

where the x is the reward based on the day, inside the StakingPromoBanner.tsx file. 

I can do this, but if somebody else wishes to complete this feel free!